### PR TITLE
feat: add settings to reduce Copilot & Cursor interference

### DIFF
--- a/.cursorignore
+++ b/.cursorignore
@@ -1,0 +1,2 @@
+*.malloy
+*.malloynb

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,9 +3,6 @@
     "github.copilot.editor.enableCodeActions": false,
     "cursor.cmdk.autoSelect": false,
     "cursor.cpp.disabledLanguages": [
-        "markdown",
-        "plaintext",
-        "malloy",
-        "malloynb"
+        "malloy"
     ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,11 @@
+{
+    "github.copilot.editor.enableAutoCompletions": false,
+    "github.copilot.editor.enableCodeActions": false,
+    "cursor.cmdk.autoSelect": false,
+    "cursor.cpp.disabledLanguages": [
+        "markdown",
+        "plaintext",
+        "malloy",
+        "malloynb"
+    ]
+}


### PR DESCRIPTION
Added workspace settings to disable AI assistance:
- Copilot: disabled auto-completions and code actions
- Cursor: disabled command palette auto-select and specific file types (malloy)

Note: Cursor's inline buttons still appear in the editor despite these settings.